### PR TITLE
Properly disposed the WebClient in LoadTestToolBox.Common.Worker

### DIFF
--- a/Common/Worker.cs
+++ b/Common/Worker.cs
@@ -16,15 +16,17 @@ namespace LoadTestToolbox.Common
 
         public void Run()
         {
-            var wc = new WebClient();
-            var timer = new Stopwatch();
+            using (var wc = new WebClient())
+            {
+                var timer = new Stopwatch();
 
-            timer.Start();
-            wc.DownloadString(url);
-            timer.Stop();
+                timer.Start();
+                wc.DownloadString(url);
+                timer.Stop();
 
-            var ms = (double)timer.ElapsedTicks / TimeSpan.TicksPerMillisecond;
-            OnComplete?.Invoke(ms, null);
+                var ms = (double)timer.ElapsedTicks / TimeSpan.TicksPerMillisecond;
+                OnComplete?.Invoke(ms, null);
+            }
         }
     }
 }


### PR DESCRIPTION
The WebClient class extends System.ComponentModel.Component which
implements IDisposable. However, the WebClient object in
LoadTestToolBox.Common.Worker.Run() is not disposed. This puts unnecessary
pressure on memory and the GC. (Fixes #9)