### PR TITLE
Fixed elapsed time calculation #15

### DIFF
--- a/Common/Worker.cs
+++ b/Common/Worker.cs
@@ -31,8 +31,7 @@ namespace LoadTestToolbox.Common
                 }
                 timer.Stop();
 
-                var ms = (double)timer.ElapsedTicks / TimeSpan.TicksPerMillisecond;
-                OnComplete?.Invoke(ms, null);
+                OnComplete?.Invoke(timer.Elapsed.TotalMilliseconds, null);
             }
         }
     }


### PR DESCRIPTION
Using StopWatch Elapsed.TotalMilliseconds instead of calculation